### PR TITLE
Default contact sensor battery value to 100% when unknown

### DIFF
--- a/lib/device_set.js
+++ b/lib/device_set.js
@@ -194,7 +194,7 @@ function DeviceSetModule(config, log, homebridge, vivintApi, ThermostatCharacter
     }
 
     contactBatteryLevelValue() {
-      return this.data.BatteryLevel || 1
+      return this.data.BatteryLevel || 100
     }
 
     notify() {


### PR DESCRIPTION
This resolves an issue when using non-Vivint-branded contact sensors, where battery level is always reported as 1%, which forces it to always report to HomeKit as low battery even with the config parameter being set to 0.